### PR TITLE
Remove link to page with build insttuctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This short guide aims to get you started with the [Symbiotic EDA](https://www.symbioticeda.com/) Formal Verification tools.
 
-It assumes you are using the Symbiotic Suite. If that is not the case you can learn how to [build and install the tools here](https://symbiyosys.readthedocs.io/en/latest/quickstart.html#installing).
-
 ## Install the tools and the license
 
 You will have been sent the license and a link to download the tools. 


### PR DESCRIPTION
The user doesn't need to go through those steps to install the tools. The download link is enough. The information on how to build the tools from source is only relevant when using the free version.